### PR TITLE
Add co-broadcast guest support — download host's stream when target is a guest

### DIFF
--- a/instarec/instagram/cookies.py
+++ b/instarec/instagram/cookies.py
@@ -18,6 +18,7 @@ BASE_HEADERS = {
 
 USER_API_URL = "https://www.instagram.com/web/search/topsearch/?query={username}"
 LIVE_API_URL = "https://www.instagram.com/api/v1/live/web_info/?target_user_id={user_id}"
+STORY_FEED_URL = "https://www.instagram.com/api/v1/feed/user/{user_id}/story/"
 REELS_TRAY_URL = "https://www.instagram.com/api/v1/live/reels_tray_broadcasts/"
 
 
@@ -117,6 +118,22 @@ class CookieClient:
                     if mpd_url := host_data.get("dash_abr_playback_url"):
                         log.API.info(f"Found MPD via co-broadcast host {host_username}: {mpd_url}")
                         return mpd_url
+
+            # Try the user's story feed — Instagram includes a "broadcast"
+            # field when the user is in any live broadcast (host or guest).
+            # Unlike the reels tray this works for any user, not just followed accounts.
+            log.API.debug(f"Checking story feed for {identifier}'s broadcast...")
+            try:
+                story_data = await self._get(session, STORY_FEED_URL.format(user_id=identifier))
+                broadcast = story_data.get("broadcast")
+                if broadcast:
+                    if mpd_url := broadcast.get("dash_abr_playback_url"):
+                        host = broadcast.get("broadcast_owner", {})
+                        host_username = host.get("username", identifier)
+                        log.API.info(f"Found broadcast via story feed (host: {host_username}): {mpd_url}")
+                        return mpd_url
+            except (UserNotLiveError, AuthError, InstagramError):
+                log.API.debug("Story feed lookup failed.")
 
             # Last resort: search the reels tray for the user appearing as a
             # co-broadcaster in someone else's active broadcast.

--- a/instarec/instagram/cookies.py
+++ b/instarec/instagram/cookies.py
@@ -18,6 +18,7 @@ BASE_HEADERS = {
 
 USER_API_URL = "https://www.instagram.com/web/search/topsearch/?query={username}"
 LIVE_API_URL = "https://www.instagram.com/api/v1/live/web_info/?target_user_id={user_id}"
+REELS_TRAY_URL = "https://www.instagram.com/api/v1/live/reels_tray_broadcasts/"
 
 
 class CookieClient:
@@ -89,14 +90,20 @@ class CookieClient:
                 identifier = user_id
 
             log.API.info(f"Checking live status for {identifier}...")
-            live_data = await self._get(session, LIVE_API_URL.format(user_id=identifier))
+            # A 404 means the user isn't hosting a broadcast; catch it so we can
+            # still attempt the co-broadcast fallbacks below.
+            try:
+                live_data = await self._get(session, LIVE_API_URL.format(user_id=identifier))
+            except UserNotLiveError:
+                live_data = {}
+
             if mpd_url := live_data.get("dash_abr_playback_url"):
                 log.API.info(f"Found MPD for {identifier}: {mpd_url}")
                 return mpd_url
 
             # The user may be a guest in a co-broadcast hosted by someone else.
-            # In that case the response won't have an MPD URL but may contain
-            # broadcast_owner pointing to the actual host.
+            # Some API versions return the host's broadcast object even when
+            # querying a guest; check broadcast_owner for that case.
             broadcast_owner = live_data.get("broadcast_owner")
             if broadcast_owner:
                 host_id = str(broadcast_owner.get("pk", ""))
@@ -110,5 +117,31 @@ class CookieClient:
                     if mpd_url := host_data.get("dash_abr_playback_url"):
                         log.API.info(f"Found MPD via co-broadcast host {host_username}: {mpd_url}")
                         return mpd_url
+
+            # Last resort: search the reels tray for the user appearing as a
+            # co-broadcaster in someone else's active broadcast.
+            # Note: limited to broadcasts by accounts the authenticated user follows.
+            log.API.debug(f"Searching reels tray for {identifier} as a co-broadcaster...")
+            try:
+                reels_data = await self._get(session, REELS_TRAY_URL)
+                for broadcast in reels_data.get("broadcasts", []):
+                    for co in broadcast.get("cobroadcasters", []):
+                        if str(co.get("pk", "")) == str(identifier):
+                            host = broadcast.get("broadcast_owner", {})
+                            host_id = str(host.get("pk", ""))
+                            host_username = host.get("username", host_id)
+                            log.API.info(
+                                f"Found {identifier} as guest in {host_username}'s broadcast. "
+                                f"Fetching host's broadcast..."
+                            )
+                            if mpd_url := broadcast.get("dash_abr_playback_url"):
+                                log.API.info(f"Found MPD via reels tray host {host_username}: {mpd_url}")
+                                return mpd_url
+                            host_data = await self._get(session, LIVE_API_URL.format(user_id=host_id))
+                            if mpd_url := host_data.get("dash_abr_playback_url"):
+                                log.API.info(f"Found MPD via reels tray host {host_username}: {mpd_url}")
+                                return mpd_url
+            except (UserNotLiveError, AuthError, InstagramError):
+                log.API.debug("Reels tray lookup failed.")
 
             raise UserNotLiveError(f"{identifier} is not currently live.")

--- a/instarec/instagram/cookies.py
+++ b/instarec/instagram/cookies.py
@@ -93,4 +93,22 @@ class CookieClient:
             if mpd_url := live_data.get("dash_abr_playback_url"):
                 log.API.info(f"Found MPD for {identifier}: {mpd_url}")
                 return mpd_url
+
+            # The user may be a guest in a co-broadcast hosted by someone else.
+            # In that case the response won't have an MPD URL but may contain
+            # broadcast_owner pointing to the actual host.
+            broadcast_owner = live_data.get("broadcast_owner")
+            if broadcast_owner:
+                host_id = str(broadcast_owner.get("pk", ""))
+                if host_id and host_id != str(identifier):
+                    host_username = broadcast_owner.get("username", host_id)
+                    log.API.info(
+                        f"{identifier} is a guest in a co-broadcast hosted by {host_username}. "
+                        f"Fetching host's broadcast..."
+                    )
+                    host_data = await self._get(session, LIVE_API_URL.format(user_id=host_id))
+                    if mpd_url := host_data.get("dash_abr_playback_url"):
+                        log.API.info(f"Found MPD via co-broadcast host {host_username}: {mpd_url}")
+                        return mpd_url
+
             raise UserNotLiveError(f"{identifier} is not currently live.")

--- a/instarec/instagram/credentials.py
+++ b/instarec/instagram/credentials.py
@@ -149,6 +149,26 @@ class CredentialsClient:
                     log.API.info(f"Found MPD via co-broadcast host {host_username}: {mpd_url}")
                     return mpd_url
 
+        # Try the user's story feed — Instagram includes a "broadcast"
+        # field when the user is in any live broadcast (host or guest).
+        # Unlike the reels tray this works for any user, not just followed accounts.
+        log.API.debug(f"Checking story feed for {identifier}'s broadcast...")
+        try:
+            story_data = self._private_request_with_retry(
+                f"feed/user/{identifier}/story/",
+                f"Retrying story feed for '{identifier}'...",
+                f"Story feed for '{identifier}' not available",
+            )
+            broadcast = story_data.get("broadcast")
+            if broadcast:
+                if mpd_url := broadcast.get("dash_abr_playback_url"):
+                    host = broadcast.get("broadcast_owner", {})
+                    host_username = host.get("username", identifier)
+                    log.API.info(f"Found broadcast via story feed (host: {host_username}): {mpd_url}")
+                    return mpd_url
+        except Exception:
+            log.API.debug("Story feed lookup failed.")
+
         # Last resort: search the reels tray for the user appearing as a
         # co-broadcaster in someone else's active broadcast.
         # Note: limited to broadcasts by accounts the authenticated user follows.

--- a/instarec/instagram/credentials.py
+++ b/instarec/instagram/credentials.py
@@ -120,4 +120,26 @@ class CredentialsClient:
         if mpd_url := live_data.get("dash_abr_playback_url"):
             log.API.info(f"Found MPD for {identifier}: {mpd_url}")
             return mpd_url
+
+        # The user may be a guest in a co-broadcast hosted by someone else.
+        # In that case the response won't have an MPD URL but may contain
+        # broadcast_owner pointing to the actual host.
+        broadcast_owner = live_data.get("broadcast_owner")
+        if broadcast_owner:
+            host_id = str(broadcast_owner.get("pk", ""))
+            if host_id and host_id != str(identifier):
+                host_username = broadcast_owner.get("username", host_id)
+                log.API.info(
+                    f"{identifier} is a guest in a co-broadcast hosted by {host_username}. "
+                    f"Fetching host's broadcast..."
+                )
+                host_data = self._private_request_with_retry(
+                    f"live/web_info/?target_user_id={host_id}",
+                    f"Retrying MPD fetch for co-broadcast host '{host_id}'...",
+                    f"Co-broadcast host '{host_id}' not found or not currently live",
+                )
+                if mpd_url := host_data.get("dash_abr_playback_url"):
+                    log.API.info(f"Found MPD via co-broadcast host {host_username}: {mpd_url}")
+                    return mpd_url
+
         raise UserNotLiveError(f"{identifier} is not currently live.")

--- a/instarec/instagram/credentials.py
+++ b/instarec/instagram/credentials.py
@@ -112,18 +112,25 @@ class CredentialsClient:
             identifier = user_data.get("user", {}).get("pk")
 
         log.API.debug(f"Checking live status for {identifier}...")
-        live_data = self._private_request_with_retry(
-            f"live/web_info/?target_user_id={identifier}",
-            f"Retrying MPD fetch for '{identifier}'...",
-            f"User '{identifier}' not found or not currently live",
-        )
+        # A 404 (raised as UserNotFound by instagrapi) means the user isn't
+        # hosting a broadcast; catch it so we can still try co-broadcast fallbacks.
+        # We know the user exists at this point, so UserNotFound here means "not live".
+        try:
+            live_data = self._private_request_with_retry(
+                f"live/web_info/?target_user_id={identifier}",
+                f"Retrying MPD fetch for '{identifier}'...",
+                f"User '{identifier}' not found or not currently live",
+            )
+        except UserNotFound:
+            live_data = {}
+
         if mpd_url := live_data.get("dash_abr_playback_url"):
             log.API.info(f"Found MPD for {identifier}: {mpd_url}")
             return mpd_url
 
         # The user may be a guest in a co-broadcast hosted by someone else.
-        # In that case the response won't have an MPD URL but may contain
-        # broadcast_owner pointing to the actual host.
+        # Some API versions return the host's broadcast object even when
+        # querying a guest; check broadcast_owner for that case.
         broadcast_owner = live_data.get("broadcast_owner")
         if broadcast_owner:
             host_id = str(broadcast_owner.get("pk", ""))
@@ -141,5 +148,39 @@ class CredentialsClient:
                 if mpd_url := host_data.get("dash_abr_playback_url"):
                     log.API.info(f"Found MPD via co-broadcast host {host_username}: {mpd_url}")
                     return mpd_url
+
+        # Last resort: search the reels tray for the user appearing as a
+        # co-broadcaster in someone else's active broadcast.
+        # Note: limited to broadcasts by accounts the authenticated user follows.
+        log.API.debug(f"Searching reels tray for {identifier} as a co-broadcaster...")
+        try:
+            reels_data = self._private_request_with_retry(
+                "live/reels_tray_broadcasts/",
+                "Retrying reels tray fetch...",
+                "Could not access reels tray",
+            )
+            for broadcast in reels_data.get("broadcasts", []):
+                for co in broadcast.get("cobroadcasters", []):
+                    if str(co.get("pk", "")) == str(identifier):
+                        host = broadcast.get("broadcast_owner", {})
+                        host_id = str(host.get("pk", ""))
+                        host_username = host.get("username", host_id)
+                        log.API.info(
+                            f"Found {identifier} as guest in {host_username}'s broadcast. "
+                            f"Fetching host's broadcast..."
+                        )
+                        if mpd_url := broadcast.get("dash_abr_playback_url"):
+                            log.API.info(f"Found MPD via reels tray host {host_username}: {mpd_url}")
+                            return mpd_url
+                        host_data = self._private_request_with_retry(
+                            f"live/web_info/?target_user_id={host_id}",
+                            f"Retrying MPD fetch for reels tray host '{host_id}'...",
+                            f"Reels tray host '{host_id}' not found or not currently live",
+                        )
+                        if mpd_url := host_data.get("dash_abr_playback_url"):
+                            log.API.info(f"Found MPD via reels tray host {host_username}: {mpd_url}")
+                            return mpd_url
+        except Exception:
+            log.API.debug("Reels tray lookup failed.")
 
         raise UserNotLiveError(f"{identifier} is not currently live.")


### PR DESCRIPTION
## Summary

When two users go live together on Instagram, only the host has an active broadcast. If you try to download the guest's stream directly, instarec currently fails with a "not currently live" error even though the guest is visibly live. This PR adds automatic detection and fallback so that specifying a guest's username or ID transparently downloads the host's broadcast instead.

## Root cause

Instagram's `live/web_info/?target_user_id={id}` endpoint returns HTTP 404 for users who are live as a guest rather than a host. The previous code raised `UserNotLiveError` immediately on 404 with no further attempt to locate the broadcast.

## What this changes

When `live/web_info` fails to return an MPD URL, the lookup now falls through three additional steps before giving up:

1. **`broadcast_owner` check** — some API responses include the host's broadcast object even when querying a guest; if present, it's used directly.
2. **Story feed** (`feed/user/{id}/story/`) — Instagram's story feed API includes a `broadcast` field when a user is participating in any live broadcast, whether as host or guest. This works for any user regardless of follow relationship, and is how the Instagram app itself shows the "LIVE" indicator on story rings.
3. **Reels tray** (`live/reels_tray_broadcasts/`) — searches active broadcasts for the user appearing as a co-broadcaster. Kept as a last resort; limited to broadcasts by accounts the authenticated user follows.

Both `CookieClient` and `CredentialsClient` are updated consistently.

## Testing

Tested and working with both cookie and credentials authentication. On the happy path (downloading a host directly), the existing `live/web_info` call succeeds as before with no additional requests made.